### PR TITLE
Fix: reliable Launch at Login on macOS

### DIFF
--- a/AirBattery/Supports/AirBatteryApp.swift
+++ b/AirBattery/Supports/AirBatteryApp.swift
@@ -502,3 +502,29 @@ func refeshPinnedBar(unpin: String? = nil) {
     DispatchQueue.main.async { for e in expItems { NSStatusBar.system.removeStatusItem(e) } }
     pinnedItems.removeAll{ expNames.contains($0.button?.toolTip ?? "") }
 }
+
+@discardableResult
+func ensureLoginItem(enabled: Bool) -> Bool {
+    let helperBundleIdentifier = "com.lihaoyun6.AirBatteryHelper"
+    if #available(macOS 13.0, *) {
+        do {
+            if enabled {
+                try SMAppService.mainApp.register()
+            } else {
+                try SMAppService.mainApp.unregister()
+            }
+            return true
+        } catch {
+            NSLog("[AirBattery] SMAppService register/unregister failed: \(error.localizedDescription)")
+            return false
+        }
+    } else {
+        let ok = SMLoginItemSetEnabled(helperBundleIdentifier as CFString, enabled)
+        if !ok { NSLog("[AirBattery] SMLoginItemSetEnabled failed for \(helperBundleIdentifier)") }
+        return ok
+    }
+}
+
+func registerDefaults() {
+    UserDefaults.standard.register(defaults: ["LaunchAtLogin": false])
+}


### PR DESCRIPTION
This PR ensures AirBattery reliably launches at login by using ServiceManagement APIs.\n\n- macOS 13+: SMAppService.mainApp.register()/unregister()\n- Older macOS: SMLoginItemSetEnabled("com.lihaoyun6.AirBatteryHelper")\n- Calls logic on app launch using "LaunchAtLogin" user default and registers a default.\n\nContext: users observed intermittent failure to launch at login after updates where cached app copies (Sparkle) confused login items. This avoids path fragility and relies on supported APIs.