### PR TITLE
Stability: prevent unexpected termination (auto/sudden)

### DIFF
--- a/AirBattery/Info.plist
+++ b/AirBattery/Info.plist
@@ -15,6 +15,10 @@
 	</array>
 	<key>NSAppleScriptEnabled</key>
 	<true/>
+	<key>NSDisableAutomaticTermination</key>
+	<true/>
+	<key>NSSupportsSuddenTermination</key>
+	<false/>
 	<key>OSAScriptingDefinition</key>
 	<string>Scriptable</string>
 	<key>SUFeedURL</key>

--- a/AirBattery/Supports/AirBatteryApp.swift
+++ b/AirBattery/Supports/AirBatteryApp.swift
@@ -24,6 +24,7 @@ var menuPopover = NSPopover()
 let bleBattery = BLEBattery()
 let btdBattery = BTDBattery()
 var updateDelay = 1
+var keepAliveActivity: NSObjectProtocol? = nil
 
 @main
 struct AirBatteryApp: App {
@@ -275,6 +276,9 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate, UNUserNotifi
     }
     
     func applicationDidFinishLaunching(_ aNotification: Notification) {
+        let opts: ProcessInfo.ActivityOptions = [.automaticTerminationDisabled, .suddenTerminationDisabled]
+        keepAliveActivity = ProcessInfo.processInfo.beginActivity(options: opts, reason: "AirBattery menu bar monitoring")
+
         if showOn == "dock" || showOn == "both" {
             let tipID = "ab.docktile-power.note"
             let never = ud.object(forKey: "neverRemindMe") as! [String]
@@ -295,6 +299,8 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate, UNUserNotifi
     }
     
     func applicationWillTerminate(_ notification: Notification) {
+        if let act = keepAliveActivity { ProcessInfo.processInfo.endActivity(act) }
+
         _ = process(path: "/usr/bin/killall", arguments: ["idevicesyslog"])
     }
     


### PR DESCRIPTION
This PR reduces unexpected exits by:\n\n- Info.plist: NSDisableAutomaticTermination=true, NSSupportsSuddenTermination=false\n- App: beginActivity with [.automaticTerminationDisabled, .suddenTerminationDisabled] at launch; end on terminate\n\nContext: reports of app closing on its own or after sleep. This change prevents macOS from automatically/suddenly terminating the app when running as a menu bar utility. The app already refreshes state on wake; this keeps the process alive.