### PR TITLE
feat: Add Liquid Glass compat & UI polish

### DIFF
--- a/AirBattery.xcodeproj/project.pbxproj
+++ b/AirBattery.xcodeproj/project.pbxproj
@@ -39,6 +39,8 @@
 		184ADF0C2DDB6C9F004791F0 /* Supports.swift in Sources */ = {isa = PBXBuildFile; fileRef = 184ADEFD2DDB6C9F004791F0 /* Supports.swift */; };
 		184ADF0D2DDB6C9F004791F0 /* Supports.swift in Sources */ = {isa = PBXBuildFile; fileRef = 184ADEFD2DDB6C9F004791F0 /* Supports.swift */; };
 		184ADF0E2DDB83EC004791F0 /* abt in CopyFiles */ = {isa = PBXBuildFile; fileRef = 184ADED12DDB2B37004791F0 /* abt */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
+		184ADF102DFCA001004791F0 /* LiquidGlassCompat.swift in Sources */ = {isa = PBXBuildFile; fileRef = 184ADF0F2DFCA001004791F0 /* LiquidGlassCompat.swift */; };
+		184ADF112DFCA001004791F0 /* LiquidGlassCompat.swift in Sources */ = {isa = PBXBuildFile; fileRef = 184ADF0F2DFCA001004791F0 /* LiquidGlassCompat.swift */; };
 		185AE80E2BA6041400FE1AA2 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = 185AE80D2BA6041400FE1AA2 /* main.swift */; };
 		185E382D2C2733B9005578EC /* BTDBattery.swift in Sources */ = {isa = PBXBuildFile; fileRef = 185E382C2C2733B9005578EC /* BTDBattery.swift */; };
 		18892A892B81F8320017377E /* WidgetKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 18892A882B81F8320017377E /* WidgetKit.framework */; };
@@ -147,6 +149,7 @@
 		184ADEFC2DDB6C9F004791F0 /* Sparkle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sparkle.swift; sourceTree = "<group>"; };
 		184ADEFD2DDB6C9F004791F0 /* Supports.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Supports.swift; sourceTree = "<group>"; };
 		184ADEFE2DDB6C9F004791F0 /* WindowAccessor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowAccessor.swift; sourceTree = "<group>"; };
+		184ADF0F2DFCA001004791F0 /* LiquidGlassCompat.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiquidGlassCompat.swift; sourceTree = "<group>"; };
 		185AE80D2BA6041400FE1AA2 /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
 		185E382C2C2733B9005578EC /* BTDBattery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTDBattery.swift; sourceTree = "<group>"; };
 		186671CC2B791CF700D4D27B /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -289,6 +292,7 @@
 				184ADEF62DDB6C9F004791F0 /* CommandLineTool.swift */,
 				184ADEF72DDB6C9F004791F0 /* GroupForm.swift */,
 				184ADEF82DDB6C9F004791F0 /* InfoButton.swift */,
+				184ADF0F2DFCA001004791F0 /* LiquidGlassCompat.swift */,
 				184ADEF92DDB6C9F004791F0 /* logReader.sh */,
 				184ADEFA2DDB6C9F004791F0 /* Multipeer.swift */,
 				184ADEFB2DDB6C9F004791F0 /* Scriptable.sdef */,
@@ -548,6 +552,7 @@
 				184ADF072DDB6C9F004791F0 /* Sparkle.swift in Sources */,
 				184ADF082DDB6C9F004791F0 /* Supports.swift in Sources */,
 				184ADF092DDB6C9F004791F0 /* WindowAccessor.swift in Sources */,
+				184ADF102DFCA001004791F0 /* LiquidGlassCompat.swift in Sources */,
 				1819E94C2CC2A8C2007B95E9 /* BatteryAlertView.swift in Sources */,
 				185E382D2C2733B9005578EC /* BTDBattery.swift in Sources */,
 				18347DCE2B88417500A78DF6 /* BatteryView.swift in Sources */,
@@ -572,6 +577,7 @@
 			files = (
 				18892AA22B82F0880017377E /* AirBatteryModel.swift in Sources */,
 				184ADF0C2DDB6C9F004791F0 /* Supports.swift in Sources */,
+				184ADF112DFCA001004791F0 /* LiquidGlassCompat.swift in Sources */,
 				18EF7E632C141CB70065A9E1 /* BatteryWidget3.swift in Sources */,
 				18892AA32B82F09C0017377E /* InternalBattery.swift in Sources */,
 				18892A8E2B81F8320017377E /* widgetBundle.swift in Sources */,
@@ -635,7 +641,7 @@
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 148;
 				DEVELOPMENT_ASSET_PATHS = "\"AirBatteryHelper/Preview Content\"";
-				DEVELOPMENT_TEAM = L4T783637F;
+				DEVELOPMENT_TEAM = "";
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu17;
@@ -647,7 +653,7 @@
 					"@executable_path/../Frameworks",
 				);
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
-				MACOSX_DEPLOYMENT_TARGET = 11.0;
+				MACOSX_DEPLOYMENT_TARGET = 12.0;
 				MARKETING_VERSION = 1.4.8;
 				PRODUCT_BUNDLE_IDENTIFIER = com.lihaoyun6.AirBatteryHelper;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -669,7 +675,7 @@
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 148;
 				DEVELOPMENT_ASSET_PATHS = "\"AirBatteryHelper/Preview Content\"";
-				DEVELOPMENT_TEAM = L4T783637F;
+				DEVELOPMENT_TEAM = "";
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu17;
@@ -681,7 +687,7 @@
 					"@executable_path/../Frameworks",
 				);
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
-				MACOSX_DEPLOYMENT_TARGET = 11.0;
+				MACOSX_DEPLOYMENT_TARGET = 12.0;
 				MARKETING_VERSION = 1.4.8;
 				PRODUCT_BUNDLE_IDENTIFIER = com.lihaoyun6.AirBatteryHelper;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -821,7 +827,7 @@
 				CURRENT_PROJECT_VERSION = 163;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"AirBattery/Preview Content\"";
-				DEVELOPMENT_TEAM = L4T783637F;
+				DEVELOPMENT_TEAM = "";
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -835,7 +841,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 11.0;
+				MACOSX_DEPLOYMENT_TARGET = 12.0;
 				MARKETING_VERSION = 1.6.3;
 				PRODUCT_BUNDLE_IDENTIFIER = com.lihaoyun6.AirBattery;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -855,7 +861,7 @@
 				CURRENT_PROJECT_VERSION = 163;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"AirBattery/Preview Content\"";
-				DEVELOPMENT_TEAM = L4T783637F;
+				DEVELOPMENT_TEAM = "";
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -869,7 +875,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 11.0;
+				MACOSX_DEPLOYMENT_TARGET = 12.0;
 				MARKETING_VERSION = 1.6.3;
 				PRODUCT_BUNDLE_IDENTIFIER = com.lihaoyun6.AirBattery;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -883,11 +889,11 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = L4T783637F;
+				DEVELOPMENT_TEAM = "";
 				ENABLE_HARDENED_RUNTIME = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu17;
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
-				MACOSX_DEPLOYMENT_TARGET = 11.0;
+				MACOSX_DEPLOYMENT_TARGET = 12.0;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
 				SWIFT_VERSION = 5.0;
@@ -899,11 +905,11 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = L4T783637F;
+				DEVELOPMENT_TEAM = "";
 				ENABLE_HARDENED_RUNTIME = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu17;
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
-				MACOSX_DEPLOYMENT_TARGET = 11.0;
+				MACOSX_DEPLOYMENT_TARGET = 12.0;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 			};
@@ -918,7 +924,7 @@
 				CODE_SIGN_ENTITLEMENTS = widget/widget.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 163;
-				DEVELOPMENT_TEAM = L4T783637F;
+				DEVELOPMENT_TEAM = "";
 				ENABLE_HARDENED_RUNTIME = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu17;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -932,7 +938,7 @@
 					"@executable_path/../../../../Frameworks",
 				);
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
-				MACOSX_DEPLOYMENT_TARGET = 11.0;
+				MACOSX_DEPLOYMENT_TARGET = 12.0;
 				MARKETING_VERSION = 1.6.3;
 				PRODUCT_BUNDLE_IDENTIFIER = com.lihaoyun6.AirBattery.widget;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -952,7 +958,7 @@
 				CODE_SIGN_ENTITLEMENTS = widget/widget.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 163;
-				DEVELOPMENT_TEAM = L4T783637F;
+				DEVELOPMENT_TEAM = "";
 				ENABLE_HARDENED_RUNTIME = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu17;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -966,7 +972,7 @@
 					"@executable_path/../../../../Frameworks",
 				);
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
-				MACOSX_DEPLOYMENT_TARGET = 11.0;
+				MACOSX_DEPLOYMENT_TARGET = 12.0;
 				MARKETING_VERSION = 1.6.3;
 				PRODUCT_BUNDLE_IDENTIFIER = com.lihaoyun6.AirBattery.widget;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/AirBattery/Supports/AirBatteryApp.swift
+++ b/AirBattery/Supports/AirBatteryApp.swift
@@ -9,6 +9,7 @@ import SwiftUI
 import WidgetKit
 import UserNotifications
 import IOBluetooth
+import ServiceManagement
 import Sparkle
 
 let fd = FileManager.default
@@ -45,7 +46,10 @@ struct AirBatteryApp: App {
                         onWindowOpen: { w in
                             if let w = w {
                                 //w.level = .floating
-                                w.titlebarSeparatorStyle = .none
+                                w.titlebarSeparatorStyle = .automatic
+                                w.titlebarAppearsTransparent = false
+                                w.isOpaque = true
+                                w.backgroundColor = .windowBackgroundColor
                                 guard let nsSplitView = findNSSplitVIew(view: w.contentView),
                                       let controller = nsSplitView.delegate as? NSSplitViewController else { return }
                                 controller.splitViewItems.first?.canCollapse = false
@@ -121,7 +125,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate, UNUserNotifi
                     ncDeviceCount += count
                 }
             }
-            let menuHeight = CGFloat((max(max(allDevices.count,1)+ncDeviceCount,1)+hiddenRow)*37+30+ncCount)
+            let menuHeight = CGFloat((max(max(allDevices.count,1)+ncDeviceCount,1)+hiddenRow)*37+44+ncCount)
             let mouse = NSEvent.mouseLocation
             var menuX = mouse.x
             var menuY = mouse.y
@@ -164,6 +168,10 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate, UNUserNotifi
             dockWindow.contentView?.wantsLayer = true
             dockWindow.contentView?.layer?.cornerRadius = 7
             dockWindow.contentView?.layer?.masksToBounds = true
+            if #available(macOS 26.0, *) {
+                dockWindow.backgroundColor = .clear
+                dockWindow.isOpaque = false
+            }
             dockWindow.makeKeyAndOrderFront(nil)
         }
         return true
@@ -393,6 +401,10 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate, UNUserNotifi
             if getMenuBarHeight() == 24.0 { bound.origin.y -= 6 }
             menuPopover.show(relativeTo: bound, of: button, preferredEdge: .minY)
             //menuPopover.show(relativeTo: button.bounds, of: button, preferredEdge: .minY)
+            if #available(macOS 26.0, *) {
+                menuPopover.contentViewController?.view.window?.isOpaque = false
+                menuPopover.contentViewController?.view.window?.backgroundColor = .clear
+            }
             menuPopover.contentViewController?.view.window?.makeKeyAndOrderFront(nil)
         }
     }
@@ -518,10 +530,11 @@ func ensureLoginItem(enabled: Bool) -> Bool {
     let helperBundleIdentifier = "com.lihaoyun6.AirBatteryHelper"
     if #available(macOS 13.0, *) {
         do {
+            let service = SMAppService.loginItem(identifier: helperBundleIdentifier)
             if enabled {
-                try SMAppService.mainApp.register()
+                try service.register()
             } else {
-                try SMAppService.mainApp.unregister()
+                try service.unregister()
             }
             return true
         } catch {

--- a/AirBattery/Supports/LiquidGlassCompat.swift
+++ b/AirBattery/Supports/LiquidGlassCompat.swift
@@ -1,0 +1,113 @@
+//
+//  LiquidGlassCompat.swift
+//  AirBattery
+//
+//  Created by Ryo on 2026/6/19.
+//
+
+import SwiftUI
+import WidgetKit
+
+private struct LiquidGlassEffectModifier<S: Shape>: ViewModifier {
+    let shape: S
+    let interactive: Bool
+    let tint: Color?
+
+    @ViewBuilder
+    func body(content: Content) -> some View {
+        #if compiler(>=6.2)
+        if #available(macOS 26.0, *) {
+            content
+                .glassEffect(.regular.tint(tint).interactive(interactive), in: shape)
+        } else {
+            content
+        }
+        #else
+        content
+        #endif
+    }
+}
+
+private struct LiquidGlassPanelModifier<S: Shape>: ViewModifier {
+    let shape: S
+    let interactive: Bool
+    let tint: Color?
+
+    @ViewBuilder
+    func body(content: Content) -> some View {
+        #if compiler(>=6.2)
+        if #available(macOS 26.0, *) {
+            content
+                .glassEffect(.regular.tint(tint).interactive(interactive), in: shape)
+        } else {
+            fallback(content: content)
+        }
+        #else
+        fallback(content: content)
+        #endif
+    }
+
+    @ViewBuilder
+    private func fallback(content: Content) -> some View {
+        if #available(macOS 12.0, *) {
+            content
+                .background(shape.fill(.thinMaterial))
+                .overlay(shape.stroke(Color.primary.opacity(0.08), lineWidth: 0.7))
+        } else {
+            content
+                .background(shape.fill(Color.primary.opacity(0.055)))
+                .overlay(shape.stroke(Color.primary.opacity(0.12), lineWidth: 0.7))
+        }
+    }
+}
+
+extension View {
+    func liquidGlassEffect<S: Shape>(in shape: S, interactive: Bool = false, tint: Color? = nil) -> some View {
+        modifier(LiquidGlassEffectModifier(shape: shape, interactive: interactive, tint: tint))
+    }
+
+    func liquidGlassEffect(cornerRadius: CGFloat, interactive: Bool = false, tint: Color? = nil) -> some View {
+        liquidGlassEffect(
+            in: RoundedRectangle(cornerRadius: cornerRadius, style: .continuous),
+            interactive: interactive,
+            tint: tint
+        )
+    }
+
+    func liquidGlassPanel<S: Shape>(in shape: S, interactive: Bool = false, tint: Color? = nil) -> some View {
+        modifier(LiquidGlassPanelModifier(shape: shape, interactive: interactive, tint: tint))
+    }
+
+    func liquidGlassPanel(cornerRadius: CGFloat, interactive: Bool = false, tint: Color? = nil) -> some View {
+        liquidGlassPanel(
+            in: RoundedRectangle(cornerRadius: cornerRadius, style: .continuous),
+            interactive: interactive,
+            tint: tint
+        )
+    }
+
+    @ViewBuilder
+    func liquidGlassWidgetBackground(_ fallback: Color = Color("WidgetBackground")) -> some View {
+        #if compiler(>=6.2)
+        if #available(macOS 26.0, *) {
+            containerBackground(for: .widget) {
+                Color.clear
+            }
+        } else if #available(macOS 14.0, *) {
+            containerBackground(for: .widget) {
+                fallback
+            }
+        } else {
+            background(fallback)
+        }
+        #else
+        if #available(macOS 14.0, *) {
+            containerBackground(for: .widget) {
+                fallback
+            }
+        } else {
+            background(fallback)
+        }
+        #endif
+    }
+}

--- a/AirBattery/Supports/Supports.swift
+++ b/AirBattery/Supports/Supports.swift
@@ -423,7 +423,7 @@ func getMacDeviceType() -> String {
 
 func getMacDeviceUUID() -> String? {
     let dev = IOServiceMatching("IOPlatformExpertDevice")
-    let platformExpert: io_service_t = IOServiceGetMatchingService(kIOMasterPortDefault, dev)
+    let platformExpert: io_service_t = IOServiceGetMatchingService(kIOMainPortDefault, dev)
     if platformExpert != 0 {
         if let serialNumberAsCFString = IORegistryEntryCreateCFProperty(platformExpert, kIOPlatformUUIDKey as CFString, kCFAllocatorDefault, 0)?.takeUnretainedValue() {
             IOObjectRelease(platformExpert)

--- a/AirBattery/ViewModel/BatteryAlertView.swift
+++ b/AirBattery/ViewModel/BatteryAlertView.swift
@@ -157,6 +157,7 @@ struct AlertInputView: View {
         .frame(width: 360)
         .background(BlurView(material: .menu).ignoresSafeArea())
         .clipShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
+        .liquidGlassEffect(cornerRadius: 14, interactive: true, tint: .primary.opacity(0.04))
     }
     
     func getPowerColor(_ level: Int) -> Color {

--- a/AirBattery/ViewModel/ContentView.swift
+++ b/AirBattery/ViewModel/ContentView.swift
@@ -279,6 +279,32 @@ struct BlurView: NSViewRepresentable {
     }
 }
 
+private struct PopoverToolbarButton: View {
+    let systemName: String
+    let help: String
+    var hoverColor: Color = .accentColor
+    var action: () -> Void
+    @State private var isHovered = false
+
+    var body: some View {
+        Button(action: action) {
+            Image(systemName: systemName)
+                .font(.system(size: 15, weight: .regular))
+                .frame(width: 28, height: 28)
+                .foregroundColor(isHovered ? hoverColor : .secondary)
+                .background(
+                    RoundedRectangle(cornerRadius: 7, style: .continuous)
+                        .fill(isHovered ? hoverColor.opacity(0.12) : Color.clear)
+                )
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .focusable(false)
+        .help(help)
+        .onHover { isHovered = $0 }
+    }
+}
+
 struct popover: View {
     var fromDock: Bool = false
     var allDevice: [Device]
@@ -287,15 +313,10 @@ struct popover: View {
     
     @State private var allDevices = [Device]()
     @State private var hiddenDevices = AirBatteryModel.getBlackList()
-    @State private var overReloadButton = false
     @State private var overCopyButton = false
     @State private var overHideButton = false
     @State private var overAlertButton = false
     @State private var overPinButton = false
-    @State private var overInfoButton = false
-    @State private var overQuitButton = false
-    @State private var overSettButton = false
-    @State private var overReloButton = false
     @State private var overStack = -1
     @State private var overStack2 = -1
     @State private var overStackNC = -1
@@ -320,69 +341,33 @@ struct popover: View {
                             }
                         }
                 }
-                HStack(spacing: 4){
+                HStack(spacing: 2){
                     if !fromDock {
-                        Button(action: {
+                        PopoverToolbarButton(systemName: "xmark.circle.fill", help: "Quit AirBattery".local, hoverColor: .red) {
                             NSApp.terminate(self)
-                        }, label: {
-                            Image(systemName: "xmark.circle")
-                                .font(.system(size: 14, weight: .light))
-                                .frame(width: 14, height: 14, alignment: .center)
-                                .foregroundColor(overQuitButton ? .red : .secondary)
-                                .opacity(overQuitButton ? 1 : 0.7)
-                        })
-                        .focusable(false)
-                        .buttonStyle(PlainButtonStyle())
-                        .onHover{ hovering in overQuitButton = hovering }
+                        }
                     } else {
-                        Button(action: {
+                        PopoverToolbarButton(systemName: "minus.circle.fill", help: "Hide".local, hoverColor: .myYellow) {
                             dockWindow.orderOut(nil)
-                        }, label: {
-                            Image(systemName: "minus.circle")
-                                .font(.system(size: 14, weight: .light))
-                                .frame(width: 14, height: 14, alignment: .center)
-                                .foregroundColor(overQuitButton ? .myYellow : .secondary)
-                                .opacity(overQuitButton ? 1 : 0.7)
-                        })
-                        .focusable(false)
-                        .buttonStyle(PlainButtonStyle())
-                        .onHover{ hovering in overQuitButton = hovering }
+                        }
                     }
                     
-                    Button(action: {
+                    PopoverToolbarButton(systemName: "info.circle.fill", help: "About AirBattery".local) {
                         dockWindow.orderOut(nil)
                         statusBarItem.menu?.cancelTracking()
                         openAboutPanel()
                         DispatchQueue.main.asyncAfter(deadline: .now() + 0.2){
                             NSApp.activate(ignoringOtherApps: true)
                         }
-                    }, label: {
-                        Image(systemName: "info.circle")
-                            .font(.system(size: 14, weight: .light))
-                            .frame(width: 14, height: 14, alignment: .center)
-                            .foregroundColor(overInfoButton ? .accentColor : .secondary)
-                            .opacity(overInfoButton ? 1 : 0.7)
-                    })
-                    .focusable(false)
-                    .buttonStyle(PlainButtonStyle())
-                    .onHover{ hovering in overInfoButton = hovering }
-                    Button(action: {
+                    }
+                    PopoverToolbarButton(systemName: "gearshape", help: "Settings".local) {
                         dockWindow.orderOut(nil)
                         statusBarItem.menu?.cancelTracking()
                         openSettingPanel()
-                    }, label: {
-                        Image(systemName: "gearshape")
-                            .font(.system(size: 13.6, weight: .light))
-                            .frame(width: 14, height: 14, alignment: .center)
-                            .foregroundColor(overSettButton ? .accentColor : .secondary)
-                            .opacity(overSettButton ? 1 : 0.7)
-                    })
-                    .focusable(false)
-                    .buttonStyle(PlainButtonStyle())
-                    .onHover{ hovering in overSettButton = hovering }
+                    }
                     Spacer()
                     if nearCast {
-                        Button(action: {
+                        PopoverToolbarButton(systemName: "antenna.radiowaves.left.and.right.circle", help: "Refresh Nearcast".local) {
                             netcastService.refeshAll()
                             if fromDock {
                                 dockWindow.orderOut(nil)
@@ -394,20 +379,12 @@ struct popover: View {
                                     allNearcast = getFiles(withExtension: "json", in: ncFolder)
                                 }
                             }
-                        }, label: {
-                            Image(systemName: "antenna.radiowaves.left.and.right.circle")
-                                .font(.system(size: 14, weight: .light))
-                                .frame(width: 14, height: 14, alignment: .center)
-                                .foregroundColor(overReloButton ? .accentColor : .secondary)
-                                .opacity(overReloButton ? 1 : 0.7)
-                        })
-                        .focusable(false)
-                        .buttonStyle(PlainButtonStyle())
-                        .onHover{ hovering in overReloButton = hovering }
+                        }
                     }
                 }
-                .offset(y: -3.5)
-                .padding(.horizontal, 5)
+                .padding(.top, fromDock ? 8 : 6)
+                .padding(.bottom, 4)
+                .padding(.horizontal, 8)
                 .onHover{ hovering in (overStack, overStack2) = (-1, -1) }
                 VStack(alignment:.leading,spacing: 0) {
                     if allDevices.count < 1 && hiddenDevices.count < 1{
@@ -769,6 +746,7 @@ struct popover: View {
                         .padding(.horizontal, 5)
                         .opacity(0.23)
                 )
+                .liquidGlassPanel(cornerRadius: 5, tint: .primary.opacity(0.02))
                 .offset(y: 2.5)
                 if nearCast {
                     ForEach(allNearcast.indices, id: \.self) { index in
@@ -796,6 +774,7 @@ struct popover: View {
             }
         }
         .frame(width: 352)
+        .liquidGlassEffect(cornerRadius: fromDock ? 8 : 10, interactive: true, tint: .primary.opacity(0.04))
         .onAppear { allDevices = allDevice }
         .onReceive(mainTimer) { t in
             if !fromDock && menuPopover.isShown {
@@ -974,6 +953,7 @@ struct nearcastView: View {
                 .padding(.horizontal, 5)
                 .opacity(0.23)
         )
+        .liquidGlassPanel(cornerRadius: 5, tint: .primary.opacity(0.02))
         .offset(y: 2.5)
     }
 

--- a/AirBattery/ViewModel/SettingsView.swift
+++ b/AirBattery/ViewModel/SettingsView.swift
@@ -6,8 +6,8 @@
 //
 
 import SwiftUI
-import ServiceManagement
 import WidgetKit
+import AppKit
 
 struct SettingsView: View {
     @State private var selectedItem: String? = "General"
@@ -44,6 +44,7 @@ struct SettingsView: View {
             .padding(.top, 9)
         }
         .frame(width: 600, height: 440)
+        .background(Color(nsColor: .windowBackgroundColor))
         .navigationTitle("AirBattery Settings")
     }
 }
@@ -60,7 +61,9 @@ struct GeneralView: View {
             SGroupBox(label: "Startup") {
                 SToggle("Launch at Login", isOn: $launchAtLogin)
                     .onChange(of: launchAtLogin) { newValue in
-                        SMLoginItemSetEnabled("com.lihaoyun6.AirBatteryHelper" as CFString, newValue)
+                        if !ensureLoginItem(enabled: newValue) {
+                            DispatchQueue.main.async { launchAtLogin.toggle() }
+                        }
                     }
                 Divider().opacity(0.5)
                 SPicker("Show AirBattery", selection: $showOn) {

--- a/widget/BatteryWidget.swift
+++ b/widget/BatteryWidget.swift
@@ -513,7 +513,7 @@ struct batteryWidget: Widget {
             batteryWidgetEntryView(entry: entry)
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
                 .ignoresSafeArea()
-                .widgetBackground(Color("WidgetBackground"))
+                .liquidGlassWidgetBackground()
         }
         .configurationDisplayName("Batteries")
         .description("Displays battery usage for your devices from AirBattery")

--- a/widget/BatteryWidget2.swift
+++ b/widget/BatteryWidget2.swift
@@ -382,7 +382,7 @@ struct batteryWidget2New: Widget {
             batteryWidgetEntryView2(entry: entry)
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
                 .ignoresSafeArea()
-                .widgetBackground(Color("WidgetBackground"))
+                .liquidGlassWidgetBackground()
         }
         .configurationDisplayName("Batteries")
         .description("Displays the battery usage of a specific device")
@@ -399,7 +399,7 @@ struct batteryWidget2: Widget {
             batteryWidgetEntryView2(entry: entry)
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
                 .ignoresSafeArea()
-                .widgetBackground(Color("WidgetBackground"))
+                .liquidGlassWidgetBackground()
         }
         .configurationDisplayName("Batteries")
         .description("More ways to displays battery usage for your devices")

--- a/widget/BatteryWidget3.swift
+++ b/widget/BatteryWidget3.swift
@@ -306,7 +306,7 @@ struct batteryWidget3: Widget {
             batteryWidgetEntryView3(entry: entry)
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
                 .ignoresSafeArea()
-                .widgetBackground(Color("WidgetBackground"))
+                .liquidGlassWidgetBackground()
         }
         .configurationDisplayName("Batteries")
         .description("Displays battery usage for your devices without percentage")

--- a/widget/widgetBundle.swift
+++ b/widget/widgetBundle.swift
@@ -9,12 +9,23 @@ import WidgetKit
 import SwiftUI
 
 extension View {
+    @ViewBuilder
     func widgetBackground(_ backgroundView: some View) -> some View {
-        if #available(macOS 14.0, *) {
-            return containerBackground(for: .widget) { backgroundView }
+        #if compiler(>=6.2)
+        if #available(macOS 26.0, *) {
+            containerBackground(for: .widget) { Color.clear }
+        } else if #available(macOS 14.0, *) {
+            containerBackground(for: .widget) { backgroundView }
         } else {
-            return background(backgroundView)
+            background(backgroundView)
         }
+        #else
+        if #available(macOS 14.0, *) {
+            containerBackground(for: .widget) { backgroundView }
+        } else {
+            background(backgroundView)
+        }
+        #endif
     }
 }
 


### PR DESCRIPTION
Introduce LiquidGlassCompat (compat wrapper for macOS 26 glassEffect with fallbacks) and apply liquid glass effects to popovers, alerts, and widgets. Add PopoverToolbarButton to simplify toolbar buttons and refactor popover toolbar/layout and hover state handling. Update App UI/window styling and popover behavior (background/opacity tweaks, menu sizing), make dock/popover windows non-opaque on newer macOS, and apply liquidGlassPanel/effect where appropriate. Fix login item handling to use SMAppService.loginItem and update Settings to use ensureLoginItem with rollback on failure. Fix IOService port usage (kIOMainPortDefault). Update Xcode project: register new source file references, bump macOS deployment target to 12.0 as the minimum in macOS 27 SDK. Minor widget API compatibility adjustments in widgetBundle/widget files.


## For Reference
### Previously
<img width="712" height="580" alt="Screenshot 2026-06-20 at 12 24 04 AM" src="https://github.com/user-attachments/assets/88c3b612-b74e-47a2-b3f2-2f19747c48ff" />
<img width="424" height="176" alt="Screenshot 2026-06-20 at 12 24 10 AM" src="https://github.com/user-attachments/assets/e306603f-54e1-486c-ab0c-24cba8c26d67" />

### In this PR

<img width="712" height="584" alt="Screenshot 2026-06-20 at 12 17 32 AM" src="https://github.com/user-attachments/assets/0676f02e-e256-4a6b-9f08-5927c454d057" />
<img width="424" height="200" alt="Screenshot 2026-06-20 at 12 17 40 AM" src="https://github.com/user-attachments/assets/b6b3f424-66c9-4189-9798-14b1e4cc1034" />
